### PR TITLE
Generated Typescript should use namespace keyword rather than module

### DIFF
--- a/generators/app/templates/src/app/_index.module.ts
+++ b/generators/app/templates/src/app/_index.module.ts
@@ -16,7 +16,7 @@ import { acmeMalarkey } from '../app/components/malarkey/malarkey.directive';
 declare var malarkey: any;
 declare var moment: moment.MomentStatic;
 
-module <%- appName %> {
+namespace <%- appName %> {
   'use strict';
 
   angular.module('<%- appName %>', [<%- modulesDependencies %>])


### PR DESCRIPTION
Generated Typescript should use namespace keyword rather than module
#907
